### PR TITLE
update: modify auth function, create superadmin only decorator

### DIFF
--- a/ckanext/datarequests/auth.py
+++ b/ckanext/datarequests/auth.py
@@ -40,6 +40,7 @@ def _is_any_group_member(context):
     return user_name and authz.has_user_permission_for_some_org(user_name, 'read')
 
 @chained_auth_function
+@auth_disallow_anonymous_access
 def auth_allow_superadmin_only(next_auth_function, context, data_dict=None):
     user_name = context.get('user')
     try:

--- a/ckanext/datarequests/auth.py
+++ b/ckanext/datarequests/auth.py
@@ -18,7 +18,8 @@
 # along with CKAN Data Requests Extension. If not, see <http://www.gnu.org/licenses/>.
 
 from ckan import authz
-from ckan.plugins.toolkit import asbool, config, get_action, chained_auth_function, NotFound, NotAuthorized
+from ckan.logic import NotFound
+from ckan.plugins.toolkit import asbool, config, get_action, chained_auth_function, NotAuthorized
 
 from . import constants
 

--- a/ckanext/datarequests/auth.py
+++ b/ckanext/datarequests/auth.py
@@ -18,8 +18,7 @@
 # along with CKAN Data Requests Extension. If not, see <http://www.gnu.org/licenses/>.
 
 from ckan import authz
-from ckan.logic import NotFound
-from ckan.plugins.toolkit import asbool, config, get_action, auth_disallow_anonymous_access, NotAuthorized
+from ckan.plugins.toolkit import asbool, config, get_action, auth_disallow_anonymous_access
 
 from . import constants
 
@@ -39,24 +38,7 @@ def _is_any_group_member(context):
             user_name = user_obj.name
     return user_name and authz.has_user_permission_for_some_org(user_name, 'read')
 
-
-def auth_allow_superadmin_only(action):
-    ''' Flag an auth function as requiring a superadmin user
-
-    This means that check_access will automatically raise a NotAuthorized
-    exception if a superadmin user is not provided in the context.
-    '''
-    def decorated(context, data_dict=None):
-        try:
-            if not authz.is_sysadmin(context.get('user')):
-                raise NotAuthorized('You must be a superadmin to perform this action.')
-        except NotFound:
-            raise NotAuthorized('User not found.')
-        return action(context, data_dict)
-    return decorated
-
-
-@auth_allow_superadmin_only
+@auth_disallow_anonymous_access
 def show_datarequest(context, data_dict):
     return {'success': True}
 
@@ -91,13 +73,13 @@ def comment_datarequest(context, data_dict):
     return {'success': True}
 
 
-@auth_allow_superadmin_only
+@auth_disallow_anonymous_access
 def list_datarequest_comments(context, data_dict):
     new_data_dict = {'id': data_dict['datarequest_id']}
     return show_datarequest(context, new_data_dict)
 
 
-@auth_allow_superadmin_only
+@auth_disallow_anonymous_access
 def show_datarequest_comment(context, data_dict):
     return {'success': True}
 

--- a/ckanext/datarequests/auth.py
+++ b/ckanext/datarequests/auth.py
@@ -47,10 +47,8 @@ def auth_allow_superadmin_only(action):
     exception if a superadmin user is not provided in the context.
     '''
     def decorated(context, data_dict=None):
-        user_name = context.get('user')
         try:
-            user = get_action('user_show')(context, {'id': user_name})
-            if not user.get('sysadmin', False):
+            if not authz.is_sysadmin(context.get('user')):
                 raise NotAuthorized('You must be a superadmin to perform this action.')
         except NotFound:
             raise NotAuthorized('User not found.')

--- a/ckanext/datarequests/auth.py
+++ b/ckanext/datarequests/auth.py
@@ -19,7 +19,7 @@
 
 from ckan import authz
 from ckan.logic import NotFound
-from ckan.plugins.toolkit import asbool, config, get_action, chained_auth_function, NotAuthorized
+from ckan.plugins.toolkit import asbool, config, get_action, auth_disallow_anonymous_access, chained_auth_function, NotAuthorized
 
 from . import constants
 

--- a/ckanext/datarequests/templates/datarequests/snippets/datarequest_item.html
+++ b/ckanext/datarequests/templates/datarequests/snippets/datarequest_item.html
@@ -9,7 +9,7 @@
 {% set description = h.markdown_extract(datarequest.get('description', ''), extract_length=truncate_length) %}
 {% set datarequest_id = datarequest.get('id', '') %}
 
-<li class="{{ item_class or "dataset-item" }}">
+<li class="{{ item_class or 'dataset-item' }}">
   {% block package_item_content %}
     <div class="dataset-content">
       <h3 class="dataset-heading">

--- a/ckanext/datarequests/templates/datarequests/snippets/datarequest_list.html
+++ b/ckanext/datarequests/templates/datarequests/snippets/datarequest_list.html
@@ -3,12 +3,11 @@
 <!--<h2>{{ title }}</h2>!-->
 
 {% block datarequest_search_results_list %}
+ {% if c.userobj.sysadmin %}
   {% if datarequests %}
     <ul class="dataset-list unstyled list-unstyled">
       {% for datarequest in datarequests %}
-        {% if datarequest.user_id == c.userobj.id %}
         {{ h.snippet('datarequests/snippets/datarequest_item.html', datarequest=datarequest, facet_titles=facet_titles) }}
-        {% endif %}
       {% endfor %}
     </ul>
   {% else %}
@@ -19,6 +18,24 @@
       {% endif %}
     </p>
   {% endif %}
+ {% else %}
+  {% if datarequests %}
+      <ul class="dataset-list unstyled list-unstyled">
+        {% for datarequest in datarequests %}
+         {% if datarequest.creator_user_id == c.userobj.id %}
+          {{ h.snippet('datarequests/snippets/datarequest_item.html', datarequest=datarequest, facet_titles=facet_titles) }}
+         {% endif %}
+        {% endfor %}
+      </ul>
+    {% else %}
+      <p class="empty">
+        {{ _('No Data Requests found with the given criteria') }}.
+        {% if h.check_access('create_datarequest') %}
+          {% link_for _('How about creating one?'), named_route='datarequest.new' %}</a>
+        {% endif %}
+      </p>
+    {% endif %}
+ {% endif %}
 {% endblock %}
 {% block page_pagination %}
   {{ page.pager(q=q) }}

--- a/ckanext/datarequests/templates/datarequests/snippets/datarequest_list.html
+++ b/ckanext/datarequests/templates/datarequests/snippets/datarequest_list.html
@@ -22,7 +22,7 @@
   {% if datarequests %}
       <ul class="dataset-list unstyled list-unstyled">
         {% for datarequest in datarequests %}
-         {% if datarequest.creator_user_id == c.userobj.id %}
+         {% if datarequest.user_id == c.userobj.id %}
           {{ h.snippet('datarequests/snippets/datarequest_item.html', datarequest=datarequest, facet_titles=facet_titles) }}
          {% endif %}
         {% endfor %}

--- a/ckanext/datarequests/templates/datarequests/snippets/datarequest_list.html
+++ b/ckanext/datarequests/templates/datarequests/snippets/datarequest_list.html
@@ -6,7 +6,9 @@
   {% if datarequests %}
     <ul class="dataset-list unstyled list-unstyled">
       {% for datarequest in datarequests %}
+        {% if datarequest.user_id == c.userobj.id %}
         {{ h.snippet('datarequests/snippets/datarequest_item.html', datarequest=datarequest, facet_titles=facet_titles) }}
+        {% endif %}
       {% endfor %}
     </ul>
   {% else %}


### PR DESCRIPTION
This PR introduces functionality to modify datarequests access to;

- Allow only superadmin users to list & show datarequests comments
- Modify datarequests list to only show user's created datarequests else show button to create datarequest 